### PR TITLE
Update 4

### DIFF
--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -200,7 +200,7 @@ def get_race_analysis_filter_results() -> dict:
             event['races'] = sorted(races, key=lambda d: d["race_nr"])
             events.append(event)
 
-        comp['events'] = events
+        comp['events'] = sorted(events, key=lambda d: d["boat_class"])
         competitions.append(comp)
 
     return competitions

--- a/backend/api/app.py
+++ b/backend/api/app.py
@@ -233,6 +233,7 @@ def get_matrix() -> dict:
         select(
             func.avg(model.Intermediate_Time.result_time_ms).label("mean"),
             func.min(model.Intermediate_Time.result_time_ms).label("min"),
+            func.stddev_samp(model.Intermediate_Time.result_time_ms).label("stddev"),
             func.count(model.Intermediate_Time.race_boat_id).label("cnt"),
             model.Boat_Class.additional_id_.label('id')
         )
@@ -286,6 +287,7 @@ def get_matrix() -> dict:
             'mean': time.mean,
             'delta': float(time.mean) - float(wbt),
             'count': time.cnt,
+            'stddev': time.stddev,
             'used_wbt': used_wbt
         }
     return result

--- a/backend/api/globals.py
+++ b/backend/api/globals.py
@@ -24,8 +24,6 @@ RELEVANT_CMP_TYPE_ABBREVATIONS = [
     "WCH", 
     "OG",
     "ECH",
-    "OPQR",
-    "FOQR",
     #U19, U23
     "U23WCH", 
     "JWCH",
@@ -42,16 +40,18 @@ RELEVANT_CMP_TYPE_ABBREVATIONS = [
 SECONDARY_CMP_TYPE_ABBREVIATIONS = [
     "CONT NF",
     "EO",
+    "FOQR",
+    "FPQR",
     "ID_NF",
     "MASTER_NF",
     "OE F",
     "OE_NF",
+    "OPQR",
     "UNI_F",
     "UNI_NF",
     "WRIC",
     "WRMR",
     "YOG"
-    "FPQR"
 ]
 
 BOATCLASSES_BY_GENDER_AGE_WEIGHT = {

--- a/backend/api/globals.py
+++ b/backend/api/globals.py
@@ -73,7 +73,7 @@ BOATCLASSES_BY_GENDER_AGE_WEIGHT = {
             'coxed_four': ("BM4+", "U23 Men's Coxed Four", "e784fbb3-b45f-45d5-be67-0699cdba4553"),
             'four': ("BM4-", "U23 Men's Four", "2fc7bcd7-3ccc-49eb-ab18-50ab09ae501d"),
             'eight': ("BM8+", "U23 Men's Eight", "2a2a5aa7-8592-4684-99ce-4f02679061e6"),
-            'lw_single': ("BLM1x", "U23 Lightweight Men's Single Sculls", "2a2a5aa7-8592-4684-99ce-4f02679061e6"),
+            'lw_single': ("BLM1x", "U23 Lightweight Men's Single Sculls", "a3fffabb-8d13-499c-b381-b74da92fd320"),
             'lw_double': ("BLM2x", "U23 Lightweight Men's Double Sculls", "cc8022e2-3ee1-463a-bddf-aa115d68e704"),
             'lw_quad': ("BLM4x", "U23 Lightweight Men's Quadruple Sculls", "8df04fba-76af-40c4-ac38-73f377bfb258"),
             'lw_pair': ("BLM2-", "U23 Lightweight Men's Pair", "3830f652-0963-4d75-a081-a4ef4553a10c"),

--- a/frontend/src/components/filters/berichteFilter.vue
+++ b/frontend/src/components/filters/berichteFilter.vue
@@ -215,21 +215,6 @@ export default {
       const tempObj = Object.values(data.runs)
       this.optionsRunsFineSelection = tempObj.reduce((acc, obj) => obj ? acc.concat(Object.keys(obj)) : acc, []);
 
-      if (this.startYear && this.endYear) {
-        const store = useBerichteState()
-        const data = {
-          "interval": [this.startYear, this.endYear],
-          "competition_type": this.compTypes.filter(item =>
-              this.selectedCompTypes.includes(item.display_name)).map(item => item.id),
-          "boat_class": this.boatClasses[this.selectedBoatClasses],
-          "race_phase_type": this.selectedRuns.map(item => this.optionsRuns[item]),
-        }
-        store.postFormDataMatrix(data)
-        data["competition_type"] = this.selectedCompTypes.join(", ")
-        data["race_phase_type"] = this.selectedRuns.map(item => this.optionsRuns[item]).join(", ")
-        data["race_phase_subtype"] = this.selectedRunsFineSelection.join(", ")
-        store.setLastFilterConfig(data)
-      }
     },
     async onSubmit() {
       const {valid} = await this.$refs.filterForm.validate()

--- a/frontend/src/components/filters/berichteFilter.vue
+++ b/frontend/src/components/filters/berichteFilter.vue
@@ -173,7 +173,7 @@ export default {
     initializeFilter(data) {
       this.startYear = Object.values(data.years[0])[0];
       this.endYear = Object.values(data.years[1])[0];
-      this.yearShortCutOptions = [`Zeitraum von ${this.startYear} bis ${this.endYear}`, "Aktuelles Jahr", "Aktueller OZ", "Letzter OZ"]
+      this.yearShortCutOptions = [`Gesamter Zeitraum`, "Aktuelles Jahr", "Aktueller OZ", "Letzter OZ"]
       this.selectedYearShortCutOptions = [0]
 
       this.optionsStartYear = Array.from({length: this.endYear - this.startYear + 1}, (_, i) => this.startYear + i)
@@ -270,7 +270,7 @@ export default {
       if (placement.length !== 0) {
         formData["placement"] = placement
       }
-
+      
       const store = useBerichteState()
       store.setSelectedBoatClass(this.selectedBoatClasses[0])
 
@@ -295,6 +295,7 @@ export default {
       formData["competition_type"] = this.selectedCompTypes.join(", ")
       formData["race_phase_type"] = this.selectedRuns.map(item => this.optionsRuns[item]).join(", ")
       formData["race_phase_subtype"] = this.selectedRunsFineSelection.join(", ")
+      formData["placement"] = this.selectedRanks.map(item => this.optionsRanks[item]).join(", ")
       store.setLastFilterConfig(formData)
     },
     clearFormInputs() {

--- a/frontend/src/components/filters/rennstrukturFilter.vue
+++ b/frontend/src/components/filters/rennstrukturFilter.vue
@@ -49,13 +49,13 @@
           v-model="formValid2" lazy-validation>
           <!-- Gender-->
           <v-chip-group multiple color="blue" v-model="selectedGenders">
-            <v-chip v-for="genderType in optionsGender">{{ genderType }}
+            <v-chip v-for="genderType in optionsGender">{{ genderType.charAt(0).toUpperCase() + genderType.slice(1) }}
             </v-chip>
           </v-chip-group>
 
-          <!-- Gender-->
+          <!-- Age Group -->
           <v-chip-group multiple color="blue" v-model="selectedAges">
-            <v-chip v-for="ageGroup in optionsAges">{{ ageGroup }}
+            <v-chip v-for="ageGroup in optionsAges">{{ ageGroup.charAt(0).toUpperCase() + ageGroup.slice(1) }}
             </v-chip>
           </v-chip-group>
 

--- a/frontend/src/stores/berichteStore.js
+++ b/frontend/src/stores/berichteStore.js
@@ -7,7 +7,7 @@ export const useBerichteState = defineStore({
     id: "berichte",
     state: () => ({
         filterOpen: false,
-        loading: true,
+        loading: false,
         matrixTableExport: [],
         lastFilterConfig: {
           "interval": [0, 0],
@@ -15,7 +15,7 @@ export const useBerichteState = defineStore({
           "boat_class": "",
           "race_phase_type": "",
         },
-        selectedBoatClass: "Alle",
+        selectedBoatClass: "Empty",
         filterOptions: [{
             "years": [{"start_year": 0}, {"end_year": 0}],
             "boat_classes": {
@@ -264,7 +264,7 @@ export const useBerichteState = defineStore({
             return rowValues
         },
         getSelectedBoatClass(state) {
-            return state.selectedBoatClass === "Alle"
+            return state.selectedBoatClass
         },
         getBarChartData(state) {
             if (state.data.plot_data.histogram.length === 0) {

--- a/frontend/src/stores/berichteStore.js
+++ b/frontend/src/stores/berichteStore.js
@@ -140,7 +140,7 @@ export const useBerichteState = defineStore({
                 "hoffnungslauf": null,
                 "vorlauf": null,
             },
-            "ranks": ["1", "2", "3", "4-6"],
+            "ranks": [1, 2, 3, 4, 5, 6],
         }],
         data: {
             "results": null,
@@ -253,7 +253,7 @@ export const useBerichteState = defineStore({
                             item[0],
                             formatMilliseconds(Number(data["wbt"])),
                             formatMilliseconds(Number(data["mean"])),
-                            formatMilliseconds(Number(data["delta"])),
+                            formatMilliseconds(Number(data["stddev"])),
                             data["count"]
                         ])
                         }

--- a/frontend/src/views/Berichte.vue
+++ b/frontend/src/views/Berichte.vue
@@ -54,8 +54,8 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
           <div v-else>
           <v-row>
             <v-col :cols="mobile ? 12 : (currentView == 'Alle' ? 8 : 5)" class="py-0 pt-1">
-              <h2 v-if="currentView != 'Alle'">{{ data.boat_classes }}</h2>
-              <v-alert type="error" variant="tonal" class="my-2" v-if="data.results === 0 && currentView != 'Alle'">
+              <h2 v-if="currentView != 'Alle'">{{ tableData.boat_classes }}</h2>
+              <v-alert type="error" variant="tonal" class="my-2" v-if="tableData.results === 0 && currentView != 'Alle'">
                 <v-row>
                   <v-col cols="12">
                     <p>Leider keine Ergebnisse gefunden.</p>
@@ -65,7 +65,7 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
               <v-alert type="success" variant="tonal" class="my-2" v-else>
                 <v-row>
                   <v-col cols="12">
-                    <p><b>{{ currentView == 'Alle' ? matrixResults : data.results }} Datensätze |
+                    <p><b>{{ currentView == 'Alle' ? matrixResults : tableData.results }} Datensätze |
                         Von {{ filterConf.interval[0] }} bis {{ filterConf.interval[1] }}</b></p>
                     <p><b>Events</b>: {{ filterConf.competition_type }}</p>
                     <p><b>Läufe</b>: {{ filterConf.race_phase_type }}</p>
@@ -74,43 +74,43 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
                   </v-col>
                 </v-row>
               </v-alert>
-              <v-table class="tableStyles" density="compact" v-if="currentView != 'Alle' && data.results > 0">
+              <v-table class="tableStyles" density="compact" v-if="currentView != 'Alle' && tableData.results > 0">
                 <tbody class="nth-grey">
                   <tr>
                     <th>Weltbestzeit</th>
                     <td>{{
-                      data.world_best_time_boat_class ?
-                        `${formatMilliseconds(data.world_best_time_boat_class)}` : "–"
+                      tableData.world_best_time_boat_class ?
+                        `${formatMilliseconds(tableData.world_best_time_boat_class)}` : "–"
                     }}
                     </td>
                   </tr>
                   <tr>
                     <th>Beste im Zeitraum</th>
-                    <td>{{ formatMilliseconds(data.best_in_period) }}</td>
+                    <td>{{ formatMilliseconds(tableData.best_in_period) }}</td>
                   </tr>
                   <tr>
                     <th>Ø Geschwindigkeit (m/s)</th>
-                    <td>{{ data["mean"]["m/s"] }}</td>
+                    <td>{{ tableData["mean"]["m/s"] }}</td>
                   </tr>
                   <tr>
                     <th>Ø t über 500m</th>
-                    <td>{{ formatMilliseconds(data["mean"]["pace 500m"]) }}</td>
+                    <td>{{ formatMilliseconds(tableData["mean"]["pace 500m"]) }}</td>
                   </tr>
                   <tr>
                     <th>Ø t über 1000m</th>
-                    <td>{{ formatMilliseconds(data["mean"]["pace 1000m"]) }}</td>
+                    <td>{{ formatMilliseconds(tableData["mean"]["pace 1000m"]) }}</td>
                   </tr>
                   <tr>
                     <th>Ø t über 2000m</th>
-                    <td>{{ formatMilliseconds(data["mean"]["mm:ss,00"]) }}</td>
+                    <td>{{ formatMilliseconds(tableData["mean"]["mm:ss,00"]) }}</td>
                   </tr>
                   <tr>
                     <th>Standardabweichung</th>
-                    <td>{{ formatMilliseconds(data.std_dev) }}</td>
+                    <td>{{ formatMilliseconds(tableData.std_dev) }}</td>
                   </tr>
                   <tr>
                     <th>Median</th>
-                    <td>{{ formatMilliseconds(data.median) }}</td>
+                    <td>{{ formatMilliseconds(tableData.median) }}</td>
                   </tr>
                   <tr>
                     <th></th>
@@ -118,28 +118,28 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
                   </tr>
                   <tr>
                     <th>Abstufung schnellste</th>
-                    <td>(n={{ data["gradation_fastest"]["results"] }})
-                      {{ formatMilliseconds(data["gradation_fastest"]["time"]) }}
+                    <td>(n={{ tableData["gradation_fastest"]["results"] }})
+                      {{ formatMilliseconds(tableData["gradation_fastest"]["time"]) }}
                     </td>
                   </tr>
                   <tr>
                     <th>Abstufung mittel</th>
-                    <td>(n={{ data["gradation_medium"]["results"] }}) {{
-                      formatMilliseconds(data["gradation_medium"]["time"])
+                    <td>(n={{ tableData["gradation_medium"]["results"] }}) {{
+                      formatMilliseconds(tableData["gradation_medium"]["time"])
                     }}
                     </td>
                   </tr>
                   <tr>
                     <th>Abstufung langsam</th>
-                    <td>(n={{ data["gradation_slow"]["results"] }}) {{
-                      formatMilliseconds(data["gradation_slow"]["time"])
+                    <td>(n={{ tableData["gradation_slow"]["results"] }}) {{
+                      formatMilliseconds(tableData["gradation_slow"]["time"])
                     }}
                     </td>
                   </tr>
                   <tr>
                     <th>Abstufung langsamste</th>
-                    <td>(n={{ data["gradation_slowest"]["results"] }})
-                      {{ formatMilliseconds(data["gradation_slowest"]["time"]) }}
+                    <td>(n={{ tableData["gradation_slowest"]["results"] }})
+                      {{ formatMilliseconds(tableData["gradation_slowest"]["time"]) }}
                     </td>
                   </tr>
                 </tbody>
@@ -176,7 +176,7 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
               </v-table>
             </v-col>
 
-            <v-col :cols="mobile ? 12 : 7" class="pa-0" v-if="currentView != 'Alle' && data.results > 0">
+            <v-col :cols="mobile ? 12 : 7" class="pa-0" v-if="currentView != 'Alle' && tableData.results > 0">
               <v-container style="width: 100%" class="pa-2">
                 <BarChart :height="'100%'" :width="'100%'" :data="getBarChartData" :chartOptions="barChartOptions"
                   class="chart-bg">
@@ -259,6 +259,7 @@ export default {
     return {
       mobile: false,
       filterOpen: false,
+      /*
       data: {
         "results": null,
         "boat_class": "",
@@ -311,7 +312,7 @@ export default {
         }
 
       }
-
+      */
 
     }
   },
@@ -325,9 +326,11 @@ export default {
         store.setFilterState(oldVal)
       }
     },
+    /*
     tableData: function (newVal,) {
       this.data = newVal
     }
+      */
   }
 }
 </script>

--- a/frontend/src/views/Berichte.vue
+++ b/frontend/src/views/Berichte.vue
@@ -259,61 +259,6 @@ export default {
     return {
       mobile: false,
       filterOpen: false,
-      /*
-      data: {
-        "results": null,
-        "boat_class": "",
-        "start_date": 0,
-        "end_date": 0,
-        "world_best_time_boat_class": 0,
-        "best_in_period": 0,
-        "mean": {
-          "mm:ss,00": 0,
-          "m/s": 0,
-          "pace 500m": 0,
-          "pace 1000m": 0
-        },
-        "std_dev": 0,
-        "median": 0,
-        "gradation_fastest": {
-          "no_of_samples": 0,
-          "time": 0
-        },
-        "gradation_medium": {
-          "no_of_samples": 0,
-          "time": 0
-        },
-        "gradation_slow": {
-          "no_of_samples": 0,
-          "time": 0
-        },
-        "gradation_slowest": {
-          "no_of_samples": 0,
-          "time": 0
-        },
-        "plot_data": {
-          "histogram": {
-            "labels":
-              [],
-            "data": []
-          },
-          "scatterPlot": {
-            "labels": [],
-            "data": []
-          },
-          "scatter_1_sd_high": {
-            "labels": [],
-            "data": []
-          },
-          "scatter_1_sd_low": {
-            "labels": [],
-            "data": []
-          }
-        }
-
-      }
-      */
-
     }
   },
   watch: {
@@ -325,12 +270,7 @@ export default {
         const store = useBerichteState()
         store.setFilterState(oldVal)
       }
-    },
-    /*
-    tableData: function (newVal,) {
-      this.data = newVal
     }
-      */
   }
 }
 </script>

--- a/frontend/src/views/Berichte.vue
+++ b/frontend/src/views/Berichte.vue
@@ -3,18 +3,15 @@ import ScatterChart from '@/components/charts/ScatterChart.vue';
 import BarChart from "@/components/charts/BarChart.vue";
 import BerichteFilter from "@/components/filters/berichteFilter.vue";
 import 'chartjs-adapter-moment';
-import {Chart as ChartJS, LinearScale, PointElement, Tooltip, Legend, TimeScale} from "chart.js";
+import { Chart as ChartJS, LinearScale, PointElement, Tooltip, Legend, TimeScale } from "chart.js";
 
 ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
 </script>
 
 <template>
-  <v-btn color="blue"
-         @click="setFilterState()" v-show="!filterOpen"
-         :class="mobile ? 'filterToggleButtonMobile mt-6 pa-0 ma-0' : 'filterToggleButton mt-6 pa-0 ma-0'"
-         :height="mobile ? 100: 180"
-         size="x-small"
-  >
+  <v-btn color="blue" @click="setFilterState()" v-show="!filterOpen"
+    :class="mobile ? 'filterToggleButtonMobile mt-6 pa-0 ma-0' : 'filterToggleButton mt-6 pa-0 ma-0'"
+    :height="mobile ? 100 : 180" size="x-small">
     <p style="writing-mode: vertical-rl; font-size: 16px; transform: rotate(180deg);">
       <v-icon style="transform: rotate(180deg); font-size: 14px; padding-left: 6px; padding-top: 10px;">mdi-filter
       </v-icon>
@@ -23,13 +20,10 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
   </v-btn>
   <v-card style="box-shadow: none; z-index: 1">
     <v-layout>
-      <v-navigation-drawer
-          v-model="filterOpen"
-          temporary
-          v-bind:style='{"margin-top": (mobile ? "71.25px" : (headerReduced ? "81px" : "159px"))}'
-          style="background-color: white; border: none"
-          width="600">
-        <berichte-filter/>
+      <v-navigation-drawer v-model="filterOpen" temporary
+        v-bind:style='{ "margin-top": (mobile ? "71.25px" : (headerReduced ? "81px" : "159px")) }'
+        style="background-color: white; border: none" width="600">
+        <berichte-filter />
       </v-navigation-drawer>
 
       <v-container :class="mobile ? 'px-5 py-2 main-container' : 'px-10 py-0 main-container'">
@@ -37,15 +31,14 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
           <h1>Berichte</h1>
           <v-icon id="tooltip-analysis-icon" color="grey" class="ml-2 v-icon--size-large">mdi-information-outline
           </v-icon>
-          <v-tooltip
-              activator="#tooltip-analysis-icon"
-              location="end"
-              open-on-hover
-          >Auf der Seite Berichte lassen sich Analysen über längere Zeiträume und weitere Filterkriterien erstellen.
+          <v-tooltip activator="#tooltip-analysis-icon" location="end" open-on-hover>Auf der Seite Berichte lassen sich
+            Analysen über längere Zeiträume und weitere Filterkriterien erstellen.
           </v-tooltip>
           <v-icon @click="openPrintDialog()" color="grey" class="ml-2 v-icon--size-large">mdi-printer</v-icon>
-          <v-icon v-if="matrixVisible" @click="exportMatrixTableData()" color="grey" class="ml-2 v-icon--size-large">mdi-table-arrow-right</v-icon>
-          <v-icon v-if="!matrixVisible" @click="exportBoatClassTableData()" color="grey" class="ml-2 v-icon--size-large">mdi-table-arrow-right</v-icon>
+          <v-icon v-if="matrixVisible" @click="exportMatrixTableData()" color="grey"
+            class="ml-2 v-icon--size-large">mdi-table-arrow-right</v-icon>
+          <v-icon v-if="!matrixVisible" @click="exportBoatClassTableData()" color="grey"
+            class="ml-2 v-icon--size-large">mdi-table-arrow-right</v-icon>
         </v-col>
         <v-divider></v-divider>
         <v-container v-if="loading" class="d-flex flex-column align-center">
@@ -67,122 +60,124 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
                 <v-row>
                   <v-col cols="12">
                     <p><b>{{ matrixVisible ? matrixResults : data.results }} Datensätze |
-                      Von {{ filterConf.interval[0] }} bis {{ filterConf.interval[1] }}</b></p>
-                    <p><b>Events</b>: {{filterConf.competition_type}}</p>
-                    <p><b>Läufe</b>: {{filterConf.race_phase_type}}</p>
-                    <p><b>Läufe (erweitert)</b>: {{filterConf.race_phase_subtype}}</p>
+                        Von {{ filterConf.interval[0] }} bis {{ filterConf.interval[1] }}</b></p>
+                    <p><b>Events</b>: {{ filterConf.competition_type }}</p>
+                    <p><b>Läufe</b>: {{ filterConf.race_phase_type }}</p>
+                    <p><b>Läufe (erweitert)</b>: {{ filterConf.race_phase_subtype }}</p>
+                    <p><b>Platzierung</b>: {{ filterConf.placement ? filterConf.placement : 'alle' }}</p>
                   </v-col>
                 </v-row>
               </v-alert>
               <v-table class="tableStyles" density="compact" v-if="!matrixVisible && data.results > 0">
                 <tbody class="nth-grey">
-                <tr>
-                  <th>Weltbestzeit</th>
-                  <td>{{
+                  <tr>
+                    <th>Weltbestzeit</th>
+                    <td>{{
                       data.world_best_time_boat_class ?
-                          `${formatMilliseconds(data.world_best_time_boat_class)}` : "–"
+                        `${formatMilliseconds(data.world_best_time_boat_class)}` : "–"
                     }}
-                  </td>
-                </tr>
-                <tr>
-                  <th>Beste im Zeitraum</th>
-                  <td>{{ formatMilliseconds(data.best_in_period) }}</td>
-                </tr>
-                <tr>
-                  <th>Ø Geschwindigkeit (m/s)</th>
-                  <td>{{ data["mean"]["m/s"] }}</td>
-                </tr>
-                <tr>
-                  <th>Ø t über 500m</th>
-                  <td>{{ formatMilliseconds(data["mean"]["pace 500m"]) }}</td>
-                </tr>
-                <tr>
-                  <th>Ø t über 1000m</th>
-                  <td>{{ formatMilliseconds(data["mean"]["pace 1000m"]) }}</td>
-                </tr>
-                <tr>
-                  <th>Ø t über 2000m</th>
-                  <td>{{ formatMilliseconds(data["mean"]["mm:ss,00"]) }}</td>
-                </tr>
-                <tr>
-                  <th>Standardabweichung</th>
-                  <td>{{ formatMilliseconds(data.std_dev) }}</td>
-                </tr>
-                <tr>
-                  <th>Median</th>
-                  <td>{{ formatMilliseconds(data.median) }}</td>
-                </tr>
-                <tr>
-                  <th></th>
-                  <td style="font-style: italic;">Bedingungen</td>
-                </tr>
-                <tr>
-                  <th>Abstufung schnellste</th>
-                  <td>(n={{ data["gradation_fastest"]["results"] }})
-                    {{ formatMilliseconds(data["gradation_fastest"]["time"]) }}
-                  </td>
-                </tr>
-                <tr>
-                  <th>Abstufung mittel</th>
-                  <td>(n={{ data["gradation_medium"]["results"] }}) {{
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Beste im Zeitraum</th>
+                    <td>{{ formatMilliseconds(data.best_in_period) }}</td>
+                  </tr>
+                  <tr>
+                    <th>Ø Geschwindigkeit (m/s)</th>
+                    <td>{{ data["mean"]["m/s"] }}</td>
+                  </tr>
+                  <tr>
+                    <th>Ø t über 500m</th>
+                    <td>{{ formatMilliseconds(data["mean"]["pace 500m"]) }}</td>
+                  </tr>
+                  <tr>
+                    <th>Ø t über 1000m</th>
+                    <td>{{ formatMilliseconds(data["mean"]["pace 1000m"]) }}</td>
+                  </tr>
+                  <tr>
+                    <th>Ø t über 2000m</th>
+                    <td>{{ formatMilliseconds(data["mean"]["mm:ss,00"]) }}</td>
+                  </tr>
+                  <tr>
+                    <th>Standardabweichung</th>
+                    <td>{{ formatMilliseconds(data.std_dev) }}</td>
+                  </tr>
+                  <tr>
+                    <th>Median</th>
+                    <td>{{ formatMilliseconds(data.median) }}</td>
+                  </tr>
+                  <tr>
+                    <th></th>
+                    <td style="font-style: italic;">Bedingungen</td>
+                  </tr>
+                  <tr>
+                    <th>Abstufung schnellste</th>
+                    <td>(n={{ data["gradation_fastest"]["results"] }})
+                      {{ formatMilliseconds(data["gradation_fastest"]["time"]) }}
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Abstufung mittel</th>
+                    <td>(n={{ data["gradation_medium"]["results"] }}) {{
                       formatMilliseconds(data["gradation_medium"]["time"])
                     }}
-                  </td>
-                </tr>
-                <tr>
-                  <th>Abstufung langsam</th>
-                  <td>(n={{ data["gradation_slow"]["results"] }}) {{
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Abstufung langsam</th>
+                    <td>(n={{ data["gradation_slow"]["results"] }}) {{
                       formatMilliseconds(data["gradation_slow"]["time"])
                     }}
-                  </td>
-                </tr>
-                <tr>
-                  <th>Abstufung langsamste</th>
-                  <td>(n={{ data["gradation_slowest"]["results"] }})
-                    {{ formatMilliseconds(data["gradation_slowest"]["time"]) }}
-                  </td>
-                </tr>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Abstufung langsamste</th>
+                    <td>(n={{ data["gradation_slowest"]["results"] }})
+                      {{ formatMilliseconds(data["gradation_slowest"]["time"]) }}
+                    </td>
+                  </tr>
                 </tbody>
               </v-table>
             </v-col>
             <v-col :cols="mobile ? 12 : 8" v-if="matrixVisible" class="py-0">
               <v-table class="tableStyles" density="compact">
                 <thead>
-                <tr>
-                  <th></th>
-                  <th>WB [t]</th>
-                  <th>Ø [t]</th>
-                  <th>Δ [s]</th>
-                  <th>n</th>
-                </tr>
+                  <tr>
+                    <th></th>
+                    <th>WB [t]</th>
+                    <th>Ø [t]</th>
+                    <th>SD [min]</th>
+                    <th>n</th>
+                  </tr>
                 </thead>
                 <tbody class="nth-grey">
-                <template v-for="row in matrixData">
-                  <tr v-if="(typeof row === 'string')" class="subheader">
-                    <th><b>{{ row }}</b></th>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                    <td></td>
-                  </tr>
-                  <tr v-else>
-                    <td v-for="item in row">
-                      {{ item }}
-                    </td>
-                  </tr>
-                </template>
+                  <template v-for="row in matrixData">
+                    <tr v-if="(typeof row === 'string')" class="subheader">
+                      <th><b>{{ row }}</b></th>
+                      <td></td>
+                      <td></td>
+                      <td></td>
+                      <td></td>
+                    </tr>
+                    <tr v-else>
+                      <td v-for="item in row">
+                        {{ item }}
+                      </td>
+                    </tr>
+                  </template>
                 </tbody>
               </v-table>
             </v-col>
 
             <v-col :cols="mobile ? 12 : 7" class="pa-0" v-if="!matrixVisible && data.results > 0">
               <v-container style="width: 100%" class="pa-2">
-                <BarChart :height="'100%'" :width="'100%'" :data="getBarChartData"
-                          :chartOptions="barChartOptions" class="chart-bg"></BarChart>
+                <BarChart :height="'100%'" :width="'100%'" :data="getBarChartData" :chartOptions="barChartOptions"
+                  class="chart-bg">
+                </BarChart>
               </v-container>
               <v-container style="width: 100%" class="pa-2">
                 <ScatterChart :height="'100%'" :width="'100%'" :data="getScatterChartData"
-                              :chartOptions="scatterChartOptions" class="chart-bg"></ScatterChart>
+                  :chartOptions="scatterChartOptions" class="chart-bg"></ScatterChart>
               </v-container>
             </v-col>
 
@@ -194,9 +189,9 @@ ChartJS.register(LinearScale, PointElement, Tooltip, Legend, TimeScale);
 </template>
 
 <script>
-import {mapState} from "pinia";
-import {useBerichteState} from "@/stores/berichteStore";
-import {useGlobalState} from "@/stores/globalStore";
+import { mapState } from "pinia";
+import { useBerichteState } from "@/stores/berichteStore";
+import { useGlobalState } from "@/stores/globalStore";
 
 export default {
   computed: {
@@ -313,7 +308,7 @@ export default {
         "plot_data": {
           "histogram": {
             "labels":
-                [],
+              [],
             "data": []
           },
           "scatterPlot": {
@@ -356,7 +351,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-
 .tableStyles {
   border: 1px solid #e0e0e0;
 
@@ -410,7 +404,10 @@ export default {
 }
 
 @media print {
-  i, .filterToggleButton, .filterToggleButtonMobile {
+
+  i,
+  .filterToggleButton,
+  .filterToggleButtonMobile {
     display: none;
   }
 }

--- a/frontend/src/views/RennstrukturanalyseEmpty.vue
+++ b/frontend/src/views/RennstrukturanalyseEmpty.vue
@@ -1,6 +1,6 @@
 <template>
 
-    <v-container class="pa-0 mt-3">
+    <v-container class="pa-0 mt-2">
         <v-alert type="info" variant="tonal" :width="mobile ? '100%' : '50%'">
             Bitte wähle ein Jahr und ein Event in dem Filter auf der linken Seite.
         </v-alert>

--- a/frontend/src/views/RennstrukturanalyseSingle.vue
+++ b/frontend/src/views/RennstrukturanalyseSingle.vue
@@ -421,9 +421,7 @@ export default {
 
           if (comp) {
             addBreadCrumbs(comp, null)
-            if (this.events.length === 0) {
-              this.events = comp.events
-            }
+            this.events = comp.events
           }
           else {
             try {
@@ -442,11 +440,11 @@ export default {
         else if (eventId && compId) {
 
           let comp = (this.getAnalysis ?? []).find(obj => obj.id == compId);
-          if (comp && this.events.length === 0) {
+          if (comp) {
             this.events = comp.events
           }
           let event = (this.events ?? []).find(obj => obj.id == eventId);
-          if (event && this.races.length === 0) {
+          if (event) {
             this.races = event.races
           }
 

--- a/frontend/src/views/RennstrukturanalyseSingle.vue
+++ b/frontend/src/views/RennstrukturanalyseSingle.vue
@@ -54,17 +54,6 @@
               </v-alert>
             </v-container>
 
-            <!--
-            <v-list density="compact">
-              <div
-                :style="{ 'display': 'grid', 'grid-template-columns': (mobile ? '1fr' : 'repeat(2, 1fr)'), 'grid-gap': '0.5rem' }">
-                <v-list-item min-height="50"
-                  style="background-color: whitesmoke; border-radius: 5px; border-left: 8px solid #5cc5ed;"
-                  class="pa-1 mx-1" v-for="event in events" :key="event" :title="event.boat_class"
-                  @click="router.push(this.$route.fullPath + '/' + event.id)"></v-list-item>
-              </div>
-            </v-list>
-            -->
             <div :style="{ display: 'flex', flexDirection: mobile ? 'column' : 'row', gap: '1rem', alignItems: 'flex-start'}">
               <div v-for="(column, colIndex) in categorizeEvents(events)" :key="colIndex"
                 :style="{flex: 1, display: 'grid', gridTemplateColumns: '1fr', gap: '0.5rem', width: '100%' }">
@@ -75,10 +64,7 @@
                 </v-list-item>
               </div>
             </div>
-
-
-
-
+            
           </v-col>
         </v-container>
       </div>

--- a/frontend/src/views/RennstrukturanalyseSingle.vue
+++ b/frontend/src/views/RennstrukturanalyseSingle.vue
@@ -34,7 +34,7 @@
                   style="background-color: whitesmoke; border-radius: 5px; border-left: 8px solid #5cc5ed;"
                   class="pa-2 mx-1" v-for="competition in getAnalysis" :key="competition" :title="competition.name"
                   :subtitle="competition.start + ' | ' + competition.venue"
-                  @click="getEvents(competition.events, competition.name, competition.id)"></v-list-item>
+                  @click="router.push(this.$route.fullPath + '/' + competition.id)"></v-list-item>
               </div>
             </v-list>
 
@@ -60,7 +60,7 @@
                 <v-list-item min-height="50"
                   style="background-color: whitesmoke; border-radius: 5px; border-left: 8px solid #5cc5ed;"
                   class="pa-1 mx-1" v-for="event in events" :key="event" :title="event.name"
-                  @click="getRaces(event.races, event.name, event.id)"></v-list-item>
+                  @click="router.push(this.$route.fullPath + '/' + event.id)"></v-list-item>
               </div>
             </v-list>
 
@@ -86,7 +86,7 @@
                 <v-list-item min-height="50"
                   style="background-color: whitesmoke; border-radius: 5px; border-left: 8px solid #5cc5ed;"
                   class="pa-2 mx-1" v-for="race in races" :key="race" :title="race.name"
-                  @click="loadRaceAnalysis(race.name, race.id)"></v-list-item>
+                  @click="router.push(this.$route.fullPath + `?race_id=${race.id}`)"></v-list-item>
               </div>
             </v-list>
 
@@ -288,14 +288,11 @@ export default {
     currentView() {
       if (this.$route.query.race_id) {
         return "ANALYSIS"
-        // Bread crumbs length 3
       }
       if (this.$route.path.match(/\/single\/[^/]+\/[^/]+/)) {
-        //Bread crumbs length 2
         return "RACES"
       }
       if (this.$route.path.match(/\/single\/[^/]+/)) {
-        // Bread crumb length 1
         return "EVENTS"
       }
       return "COMPETITIONS"
@@ -324,28 +321,6 @@ export default {
         return '00:00.00';
       }
       return new Date(ms).toISOString().slice(14, -2);
-    },
-    getEvents(competition, displayName, compId) {
-      router.push("/rennstrukturanalyse/single/" + compId)
-      competition.sort((a, b) => a.boat_class.localeCompare(b.boat_class))
-      this.events = competition
-      this.breadCrumbs.push({ title: displayName })
-    },
-    getRaces(events, displayName, eventId) {
-      router.push(this.$route.fullPath + "/" + eventId)
-      this.races = events
-      this.breadCrumbs.push({ title: displayName })
-    },
-    async loadRaceAnalysis(raceName, raceId) {
-      const store = useRennstrukturAnalyseState()
-      store.setToLoadingState(true)
-      const newPath = this.$route.fullPath + `?race_id=${raceId}`
-      router.push(newPath)
-      await store.fetchRaceData(raceId)
-      const subject = "Wettkampfergebnisse"
-      const body = `Sieh dir diese Wettkampfergebnisse an: http://${window.location.host + newPath}`
-      store.setEmailLink(`mailto:?subject=${subject}&body=${body}`)
-      store.setToLoadingState(false)
     },
     checkScreen() {
       this.windowWidth = window.innerWidth;
@@ -459,11 +434,15 @@ export default {
 
         //race
         if (raceId) {
-          if (raceId == this.competitionData.raceId) return;
+          if (raceId == this.competitionData?.raceId) return;
           else {
             store.setToLoadingState(true)
             await store.fetchRaceData(raceId);
             store.setToLoadingState(false)
+
+            const subject = "Wettkampfergebnisse"
+            const body = `Sieh dir diese Wettkampfergebnisse an: http://${window.location.host + this.$route.fullPath}`
+            store.setEmailLink(`mailto:?subject=${subject}&body=${body}`)
           }
         }
 

--- a/frontend/src/views/RennstrukturanalyseSingle.vue
+++ b/frontend/src/views/RennstrukturanalyseSingle.vue
@@ -54,15 +54,30 @@
               </v-alert>
             </v-container>
 
+            <!--
             <v-list density="compact">
               <div
                 :style="{ 'display': 'grid', 'grid-template-columns': (mobile ? '1fr' : 'repeat(2, 1fr)'), 'grid-gap': '0.5rem' }">
                 <v-list-item min-height="50"
                   style="background-color: whitesmoke; border-radius: 5px; border-left: 8px solid #5cc5ed;"
-                  class="pa-1 mx-1" v-for="event in events" :key="event" :title="event.name"
+                  class="pa-1 mx-1" v-for="event in events" :key="event" :title="event.boat_class"
                   @click="router.push(this.$route.fullPath + '/' + event.id)"></v-list-item>
               </div>
             </v-list>
+            -->
+            <div :style="{ display: 'flex', flexDirection: mobile ? 'column' : 'row', gap: '1rem', alignItems: 'flex-start'}">
+              <div v-for="(column, colIndex) in categorizeEvents(events)" :key="colIndex"
+                :style="{flex: 1, display: 'grid', gridTemplateColumns: '1fr', gap: '0.5rem', width: '100%' }">
+                <h3>{{ column.name }}</h3>
+                <v-list-item min-height="50" v-for="event in column.events" :key="event.id" :title="event.name" class="pa-1 mx-1"
+                  style="background-color: whitesmoke; border-radius: 5px; border-left: 8px solid #5cc5ed"
+                  @click="router.push($route.fullPath + '/' + event.id)">
+                </v-list-item>
+              </div>
+            </div>
+
+
+
 
           </v-col>
         </v-container>
@@ -331,7 +346,42 @@ export default {
     setRelationTimeFrom(value) {
       const store = useRennstrukturAnalyseState()
       store.setRelationTimeFrom(value)
-    }
+    },
+    sortEvents(events) {
+      const getPriority = (e) => {
+        if (e.boat_class.startsWith('P')) return 0;
+        if (e.boat_class.startsWith('L')) return 1;
+        return 2;
+      };
+
+      return events.sort((a, b) => {
+        const diff = getPriority(a) - getPriority(b);
+        if (diff !== 0) return diff;
+        return a.boat_class.localeCompare(b.boat_class);
+      });
+    },
+    categorizeEvents(events) {
+      const categories = [
+        {name: "Men's Events", events: []},
+        {name: "Women's Events", events: []},
+        {name: "Open Events", events: []}
+      ]
+
+      for (let event of events) {
+        if (event.boat_class.includes('Mix')) {
+          categories[2].events.push(event)
+        }
+        else if (event.boat_class.includes('W')) {
+          categories[1].events.push(event)
+        }
+        else {
+          categories[0].events.push(event)
+        }
+        categories[0].events = this.sortEvents(categories[0].events);
+        categories[1].events = this.sortEvents(categories[1].events);
+      }
+      return categories
+    },
   },
   watch: {
     radios(newValue) {

--- a/frontend/src/views/RennstrukturanalyseSingle.vue
+++ b/frontend/src/views/RennstrukturanalyseSingle.vue
@@ -366,7 +366,7 @@ export default {
         categories[0].events = this.sortEvents(categories[0].events);
         categories[1].events = this.sortEvents(categories[1].events);
       }
-      return categories
+      return categories.filter(cat => cat.events.length > 0);
     },
   },
   watch: {


### PR DESCRIPTION
Updates wie beschrieben in DRVStats_Berichte.xlsx
- RA: Reihenfolge der Rennen für ein Event wie bei World Rowing
- RA: gleiche Schreibweise wie in Berichte z.B. U23 statt u23, W statt w etc.
- Filter Zeitraum von 1986 bis 2025 unbenennen in Zeitraum
- als Default wenn man die Seite öffnet nichts auswählen und wie in Rennstrukturanalyse Fenster "Bitte wähle einen Zeitraum und ein Event in dem Filter auf der linken Seite."
- Filter Events updaten (aktuell kann JWCH nicht aus/abgewählt werden)
- In dem grünen Feld zu Datenanzeigen Platzierung hinzugefügt
- Datentabelle Mehrfachauswahl zeigt jetzt Standardabweichung




